### PR TITLE
Fixed asciidoc include and updated docu for webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module.exports = {
     ]
 ```
 
-The attribute `showtitle` allows h1 header to be rendered.
+The attribute `showtitle` allows h1 headers to be rendered.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ var readme = require('html!asciidoctor!./README.adoc');
 ```
 
 
-### Example config
+## Config
 
-This webpack config can load asciidoctor files.
+Config examples for loading asciidoctor files.
+
+### Webpack 1
+
 
 ``` javascript
 module.exports = {
@@ -27,6 +30,31 @@ module.exports = {
   }
 };
 ```
+
+### Webpack 2
+
+``` javascript
+    rules: [
+        {
+            test: /\.adoc/,
+            use: [
+                {
+                    loader: "html-loader"
+                },
+                {
+                    loader: "asciidoctor-loader",
+                    options: {
+                        attributes: 'showtitle'
+                    }
+                }
+            ]
+
+        }
+    ]
+```
+
+The attribute `showtitle` allows h1 header to be rendered.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ module.exports = {
             test: /\.adoc/,
             use: [
                 {
-                    loader: "html-loader"
+                    loader: "html-loader",
+                     options: {
+                        interpolate: 'require'
+                     }
                 },
                 {
                     loader: "asciidoctor-loader",
@@ -55,6 +58,9 @@ module.exports = {
 
 The attribute `showtitle` allows h1 headers to be rendered.
 
+Use the `html-loader` option `interpolate` to enable the asciidoc `include::[]` syntax.
+
+Files loaded through `include::[]` will be affected from other webpack loaders.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 const loaderUtils = require("loader-utils"),
     assign = require("object-assign"),
-    asciidoctor = require('asciidoctor.js')();
+    asciidoctor = require('asciidoctor.js')(),
+    path = require('path');
 
 // default option
 const defaultOptions = {
@@ -13,7 +14,19 @@ const defaultOptions = {
 module.exports = function (content) {
     // merge params and default config
     const query = loaderUtils.parseQuery(this.query),
-        options = assign({}, defaultOptions, query, this.options["asciidoctorLoader"]);
+        options = assign({}, defaultOptions, query, this.options["asciidoctorLoader"]),
+        includeRegExp = new RegExp(/^include::(.*)\[\]/, 'm');
+
+    let includePath,
+        includeFileName;
+
+    while (includeRegExp.test(content)) {
+        includeFileName = content.match(includeRegExp)[1];
+        includePath = path.join(`${this.context}/${includeFileName}`);
+        content = content.replace(includeRegExp, "++++\n${require("+includeFileName+"')}\n++++");
+
+    }
+
 
     this.cacheable();
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var asciidoctor = require('asciidoctor.js')();
 
 // default option
 var defaultOptions = {
-  safe: 'server',
+  safe: 'unsafe',
   sourceHighlighter: 'highlightjs'
 };
 

--- a/index.js
+++ b/index.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var loaderUtils = require("loader-utils");
-var assign = require("object-assign");
-var asciidoctor = require('asciidoctor.js')();
+const loaderUtils = require("loader-utils"),
+    assign = require("object-assign"),
+    asciidoctor = require('asciidoctor.js')();
 
 // default option
-var defaultOptions = {
-  safe: 'unsafe',
-  sourceHighlighter: 'highlightjs'
+const defaultOptions = {
+    safe: 'unsafe',
+    sourceHighlighter: 'highlightjs'
 };
 
 module.exports = function (content) {
-  // merge params and default config
-  var query = loaderUtils.parseQuery(this.query);
-  var options = assign({}, defaultOptions, query, this.options["asciidoctorLoader"]);
+    // merge params and default config
+    const query = loaderUtils.parseQuery(this.query),
+        options = assign({}, defaultOptions, query, this.options["asciidoctorLoader"]);
 
-  this.cacheable();
+    this.cacheable();
 
-  return asciidoctor.convert(content, options);
+    return asciidoctor.convert(content, options);
 };


### PR DESCRIPTION
* `include::[]` syntax is working directly through webpack
* updated docu for webpack 2