### PR TITLE
using an alternative dependecy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,4 @@
+# Changelog
+
+A downgraded version of asciidoctor.js is used because opal may slow 
+applications using this lib down.

--- a/index.js
+++ b/index.js
@@ -27,8 +27,7 @@ module.exports = function (content) {
 
     }
 
-
     this.cacheable();
 
-    return asciidoctor.convert(content, options);
+    return asciidoctor.Asciidoctor(true).$convert(content, asciidoctor.Opal.hash(options));
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/exaptis/asciidoctor-loader",
   "dependencies": {
-    "asciidoctor.js": "1.5.5-4",
+    "asciidoctor.js": "1.5.3",
     "html-loader": "^0.4.3",
     "loader-utils": "~0.2.15",
     "object-assign": "~4.1.0"


### PR DESCRIPTION
This PR uses a downgraded version of asciidoctor.js, because every version newer than `1.5.4` is slowing the webpack build down. Can be removed when a newer version fixed it.
Related issue: [issue#359](https://github.com/asciidoctor/asciidoctor.js/issues/359) 